### PR TITLE
Allow object to be passed to render text by casting it to a string

### DIFF
--- a/Grid/Render/Text.php
+++ b/Grid/Render/Text.php
@@ -12,6 +12,6 @@ class Text extends RenderAbstract
      */
     public function render()
     {
-        return $this->getValue();
+        return (string) $this->getValue();
     }
 }


### PR DESCRIPTION
When passing an object to the text render the output is [object, object], casting it to string will call to the objects __toString() allowing control over the output.